### PR TITLE
Add Google and Apple authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ A hybrid mobile application for tracking macro intakes (calories, carbs, protein
 - 🔔 **Notifications**: Get reminders and achievement notifications
 - 💾 **Local Storage**: All data stored locally on device
 
+## Authentication (Google and Apple)
+
+The app supports sign-in with Google and (on iOS) Sign in with Apple.
+
+### Setup
+
+1. Google Sign-In
+   - Create a project in Google Cloud Console and configure OAuth consent screen.
+   - Create an OAuth Client ID of type "Web application" and note the Web Client ID.
+   - Replace the placeholder in `src/App.js` for `googleWebClientId` with your Web Client ID.
+   - Android: Add a reversed client ID if needed for Google Sign-In and ensure Play Services are available.
+
+2. Apple Sign In (iOS only)
+   - Requires building on macOS with Xcode and enabling Sign in with Apple capability.
+
+### Usage
+
+On launch, unauthenticated users see the login screen with Google and Apple buttons. Successful sign-in persists locally; you can sign out from within code via the `AuthContext` API.
+
 ## Screenshots
 
 The app includes four main screens:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "react-native-svg": "^13.14.0",
     "react-native-vector-icons": "^10.0.2",
     "react-native-vision-camera": "^3.9.2",
-    "vision-camera-code-scanner": "^0.2.0"
+    "vision-camera-code-scanner": "^0.2.0",
+    "@react-native-google-signin/google-signin": "^11.0.0",
+    "@invertase/react-native-apple-authentication": "^2.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,20 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
-import {StatusBar, StyleSheet} from 'react-native';
+import {StatusBar, ActivityIndicator, View} from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
 import HomeScreen from './screens/HomeScreen';
 import CameraScreen from './screens/CameraScreen';
 import HistoryScreen from './screens/HistoryScreen';
 import ProfileScreen from './screens/ProfileScreen';
+import LoginScreen from './screens/LoginScreen';
+import { AuthProvider, AuthContext } from './context/AuthContext';
 
 const Tab = createBottomTabNavigator();
 
-const App = () => {
-  return (
-    <NavigationContainer>
-      <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
-      <Tab.Navigator
+const Tabs = () => (
+  <Tab.Navigator
         screenOptions={({route}) => ({
           tabBarIcon: ({focused, color, size}) => {
             let iconName;
@@ -42,12 +41,33 @@ const App = () => {
             fontWeight: 'bold',
           },
         })}>
-        <Tab.Screen name="Home" component={HomeScreen} />
-        <Tab.Screen name="Camera" component={CameraScreen} />
-        <Tab.Screen name="History" component={HistoryScreen} />
-        <Tab.Screen name="Profile" component={ProfileScreen} />
-      </Tab.Navigator>
-    </NavigationContainer>
+    <Tab.Screen name="Home" component={HomeScreen} />
+    <Tab.Screen name="Camera" component={CameraScreen} />
+    <Tab.Screen name="History" component={HistoryScreen} />
+    <Tab.Screen name="Profile" component={ProfileScreen} />
+  </Tab.Navigator>
+);
+
+const Root = () => {
+  const { user, initializing } = useContext(AuthContext);
+  if (initializing) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator size="large" color="#4CAF50" />
+      </View>
+    );
+  }
+  return user ? <Tabs /> : <LoginScreen />;
+};
+
+const App = () => {
+  return (
+    <AuthProvider googleWebClientId={"YOUR_WEB_CLIENT_ID_HERE"}>
+      <NavigationContainer>
+        <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
+        <Root />
+      </NavigationContainer>
+    </AuthProvider>
   );
 };
 

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,0 +1,58 @@
+import React, {createContext, useCallback, useEffect, useMemo, useState} from 'react';
+import {configureGoogleSignin, getStoredUser, signInWithApple, signInWithGoogle, signOut} from '../services/AuthService';
+
+export const AuthContext = createContext({
+  user: null,
+  initializing: true,
+  signInGoogle: async () => {},
+  signInApple: async () => {},
+  signOut: async () => {},
+  configure: (_cfg) => {},
+});
+
+export const AuthProvider = ({children, googleWebClientId}) => {
+  const [user, setUser] = useState(null);
+  const [initializing, setInitializing] = useState(true);
+
+  useEffect(() => {
+    if (googleWebClientId) {
+      configureGoogleSignin(googleWebClientId);
+    }
+    (async () => {
+      const stored = await getStoredUser();
+      if (stored) setUser(stored);
+      setInitializing(false);
+    })();
+  }, [googleWebClientId]);
+
+  const signInGoogleHandler = useCallback(async () => {
+    const u = await signInWithGoogle();
+    setUser(u);
+  }, []);
+
+  const signInAppleHandler = useCallback(async () => {
+    const u = await signInWithApple();
+    setUser(u);
+  }, []);
+
+  const signOutHandler = useCallback(async () => {
+    await signOut();
+    setUser(null);
+  }, []);
+
+  const value = useMemo(() => ({
+    user,
+    initializing,
+    signInGoogle: signInGoogleHandler,
+    signInApple: signInAppleHandler,
+    signOut: signOutHandler,
+  }), [user, initializing, signInGoogleHandler, signInAppleHandler, signOutHandler]);
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,0 +1,102 @@
+import React, {useContext} from 'react';
+import {View, Text, StyleSheet, TouchableOpacity, Image, Platform} from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+import {AuthContext} from '../context/AuthContext';
+
+const LoginScreen = () => {
+  const {signInGoogle, signInApple} = useContext(AuthContext);
+
+  return (
+    <View style={styles.container}>
+      <LinearGradient colors={["#4CAF50", "#81C784"]} style={styles.header}>
+        <Icon name="restaurant" size={64} color="#ffffff" />
+        <Text style={styles.title}>Macro Tracker</Text>
+        <Text style={styles.subtitle}>Sign in to continue</Text>
+      </LinearGradient>
+
+      <View style={styles.content}>
+        <TouchableOpacity style={styles.googleButton} onPress={signInGoogle}>
+          <Image
+            source={{ uri: 'https://developers.google.com/identity/images/g-logo.png'}}
+            style={styles.googleLogo}
+          />
+          <Text style={styles.googleText}>Continue with Google</Text>
+        </TouchableOpacity>
+
+        {Platform.OS === 'ios' && (
+          <TouchableOpacity style={styles.appleButton} onPress={signInApple}>
+            <Icon name="apple" size={22} color="#fff" />
+            <Text style={styles.appleText}>Continue with Apple</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  header: {
+    paddingTop: 120,
+    paddingBottom: 40,
+    alignItems: 'center',
+  },
+  title: {
+    color: '#ffffff',
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginTop: 10,
+  },
+  subtitle: {
+    color: '#eaf7ea',
+    fontSize: 14,
+    marginTop: 6,
+  },
+  content: {
+    padding: 24,
+  },
+  googleButton: {
+    backgroundColor: '#ffffff',
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 2,
+  },
+  googleLogo: {
+    width: 20,
+    height: 20,
+    marginRight: 10,
+  },
+  googleText: {
+    color: '#333',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  appleButton: {
+    marginTop: 12,
+    backgroundColor: '#000000',
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  appleText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+    marginLeft: 8,
+  },
+});
+
+export default LoginScreen;
+
+

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -1,0 +1,66 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { GoogleSignin } from '@react-native-google-signin/google-signin';
+import appleAuth, { AppleButton } from '@invertase/react-native-apple-authentication';
+
+const AUTH_STORAGE_KEY = 'auth_user';
+
+export const configureGoogleSignin = (webClientId) => {
+  GoogleSignin.configure({
+    webClientId,
+    offlineAccess: false,
+  });
+};
+
+export const getStoredUser = async () => {
+  const raw = await AsyncStorage.getItem(AUTH_STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+};
+
+export const signInWithGoogle = async () => {
+  await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
+  const userInfo = await GoogleSignin.signIn();
+  const user = {
+    provider: 'google',
+    id: userInfo.user.id,
+    name: userInfo.user.name,
+    email: userInfo.user.email,
+    photo: userInfo.user.photo,
+    idToken: userInfo.idToken,
+  };
+  await AsyncStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
+  return user;
+};
+
+export const signInWithApple = async () => {
+  const response = await appleAuth.performRequest({
+    requestedOperation: appleAuth.Operation.LOGIN,
+    requestedScopes: [appleAuth.Scope.EMAIL, appleAuth.Scope.FULL_NAME],
+  });
+  const user = {
+    provider: 'apple',
+    id: response.user,
+    name: response.fullName?.givenName
+      ? `${response.fullName?.givenName || ''} ${response.fullName?.familyName || ''}`.trim()
+      : undefined,
+    email: response.email,
+    identityToken: response.identityToken,
+    authorizationCode: response.authorizationCode,
+  };
+  await AsyncStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
+  return user;
+};
+
+export const signOut = async () => {
+  try {
+    const stored = await getStoredUser();
+    if (stored?.provider === 'google') {
+      try {
+        await GoogleSignin.signOut();
+      } catch (e) {}
+    }
+  } finally {
+    await AsyncStorage.removeItem(AUTH_STORAGE_KEY);
+  }
+};
+
+


### PR DESCRIPTION
- Add @react-native-google-signin/google-signin and @invertase/react-native-apple-authentication dependencies
- Create AuthService with Google/Apple sign-in and AsyncStorage persistence
- Add AuthContext for session management across the app
- Create LoginScreen with Google and Apple sign-in buttons
- Wire authentication flow in App.js to gate main tabs behind login
- Update README with setup instructions for Google and Apple auth